### PR TITLE
remove body margin

### DIFF
--- a/docs/simple.html
+++ b/docs/simple.html
@@ -9,6 +9,9 @@
       image-rendering: pixelated;
       image-rendering: -moz-crisp-edges;
     }
+    body {
+      margin: 0;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
by default common web browsers give `body` a margin of 8 pixels, which is unwanted here